### PR TITLE
Add a missing await to logout

### DIFF
--- a/lib/src/providers/cognito_provider.dart
+++ b/lib/src/providers/cognito_provider.dart
@@ -154,7 +154,7 @@ class CognitoProvider implements AuthenticationProvider {
 
   Future<AuthenticationResult> logOut() async {
     try {
-      Amplify.Auth.signOut();
+      await Amplify.Auth.signOut();
       return AuthenticationResult(success: true);
     } on AuthException catch (e) {
       print(e.message);


### PR DESCRIPTION
This adds a missing `await` call to the logout method. This was causing
issues when waiting for this to complete before continuing.

ps-id: 26EC4359-6EEA-4496-91F2-1D8711B4717C